### PR TITLE
Port to nan 1.6.2, adds node-0.12, iojs-1.X support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
   },
   'targets': [
     {
-      'target_name': 'native',
+      'target_name': 'ed25519',
       'sources': [
         'src/ed25519/keypair.c',
         'src/ed25519/sign.c',
@@ -68,6 +68,9 @@
             }]
           ]
         }]
+      ],
+      'include_dirs': [
+        "<!(node -e \"require('nan')\")"
       ]
     }
   ]

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/Release/native.node');
+module.exports = require('bindings')('ed25519');

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ed25519",
   "version": "0.0.2",
   "description": "An Ed25519 implementation for node.js",
+  "dependencies": {
+    "bindings": "^1.2.1",
+    "nan": "^1.6.1"
+  },
   "main": "index.js",
   "scripts": {
     "install": "node-gyp rebuild"
@@ -16,8 +20,8 @@
   ],
   "author": "Dave Akers",
   "license": "BSD-2-Clause",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/dazoe/ed25519.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dazoe/ed25519.git"
   }
 }

--- a/src/ed25519.cc
+++ b/src/ed25519.cc
@@ -1,38 +1,39 @@
 #include <node.h>
 #include <node_buffer.h>
+
+#include <nan.h>
+
 #include "ed25519/ed25519.h"
 
 using namespace v8;
 using namespace node;
-
-//Helper function
-static Handle<Value> V8Exception(const char* msg) {
-	return ThrowException(Exception::Error(String::New(msg)));
-}
 
 /**
  * MakeKeypair(Buffer seed)
  * seed: A 32 byte buffer
  * returns: an Object with PublicKey and PrivateKey
  **/
-Handle<Value> MakeKeypair(const Arguments& args) {
-	HandleScope scope;
+NAN_METHOD(MakeKeypair) {
+	NanScope();
 	if ((args.Length() < 1) || (!Buffer::HasInstance(args[0])) || (Buffer::Length(args[0]->ToObject()) != 32)) {
-		return V8Exception("MakeKeypair requires a 32 byte buffer");
+		return NanThrowError("MakeKeypair requires a 32 byte buffer");
 	}
 	const unsigned char* seed = (unsigned char*)Buffer::Data(args[0]->ToObject());
-	Buffer* privateKey = Buffer::New(64);
+
+	v8::Local<v8::Object> privateKey = NanNewBufferHandle(64);
+
 	unsigned char* privateKeyData = (unsigned char*)Buffer::Data(privateKey);
-	Buffer* publicKey = Buffer::New(32);
+
+	v8::Local<v8::Object> publicKey = NanNewBufferHandle(32);
 	unsigned char* publicKeyData = (unsigned char*)Buffer::Data(publicKey);
 	for (int i = 0; i < 32; i++)
 		privateKeyData[i] = seed[i];
 	crypto_sign_keypair(publicKeyData, privateKeyData);
 
-	Local<Object> result = Object::New();
-	result->Set(String::NewSymbol("publicKey"), Local<Object>::New(publicKey->handle_));
-	result->Set(String::NewSymbol("privateKey"), Local<Object>::New(privateKey->handle_));
-	return scope.Close(result);
+	Local<Object> result = NanNew<Object>();
+	result->Set(NanNew("publicKey"), publicKey);
+	result->Set(NanNew("privateKey"), privateKey);
+	NanReturnValue(result);
 }
 
 /**
@@ -44,10 +45,10 @@ Handle<Value> MakeKeypair(const Arguments& args) {
  * keyPair: the object from the MakeKeypair function
  * returns: the signature as a Buffer
  **/
-Handle<Value> Sign(const Arguments& args) {
-	HandleScope scope;
+NAN_METHOD(Sign) {
+	NanScope();
 	if ((args.Length() < 2) || (!Buffer::HasInstance(args[0]->ToObject()))) {
-		return V8Exception("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
+		return NanThrowError("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
 	}
 	unsigned char* privateKey;
 	if ((Buffer::HasInstance(args[1])) && (Buffer::Length(args[1]->ToObject()) == 32)) {
@@ -62,13 +63,13 @@ Handle<Value> Sign(const Arguments& args) {
 	} else if ((Buffer::HasInstance(args[1])) && (Buffer::Length(args[1]->ToObject()) == 64)) {
 		privateKey = (unsigned char*)Buffer::Data(args[1]->ToObject());
 	} else if ((args[1]->IsObject()) && (!Buffer::HasInstance(args[1]))) {
-		Handle<Object> privateKeyBuffer = args[1]->ToObject()->Get(String::New("privateKey"))->ToObject();
+		Handle<Object> privateKeyBuffer = args[1]->ToObject()->Get(NanNew<String>("privateKey"))->ToObject();
 		if (!Buffer::HasInstance(privateKeyBuffer)) {
-			return V8Exception("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
+			return NanThrowError("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
 		}
 		privateKey = (unsigned char*)Buffer::Data(privateKeyBuffer);
 	} else {
-		return V8Exception("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
+		return NanThrowError("Sign requires (Buffer, {Buffer(32 or 64) | keyPair object})");
 	}
 	Handle<Object> message = args[0]->ToObject();
 	const unsigned char* messageData = (unsigned char*)Buffer::Data(message);
@@ -76,12 +77,13 @@ Handle<Value> Sign(const Arguments& args) {
 	unsigned long long sigLen = 64 + messageLen;
 	unsigned char signatureMessageData[sigLen];
 	crypto_sign(signatureMessageData, &sigLen, messageData, messageLen, privateKey);
-	Buffer* signature = Buffer::New(64);
+
+	v8::Local<v8::Object> signature = NanNewBufferHandle(64);
 	unsigned char* signatureData = (unsigned char*)Buffer::Data(signature);
 	for (int i = 0; i < 64; i++) {
 		signatureData[i] = signatureMessageData[i];
 	}
-	return scope.Close(signature->handle_);
+	NanReturnValue(signature);
 }
 
 /**
@@ -91,30 +93,31 @@ Handle<Value> Sign(const Arguments& args) {
  * publicKey: publicKey to the private key that created the signature
  * returns: boolean
  **/
-Handle<Value> Verify(const Arguments& args) {
-	HandleScope scope;
-	if ((args.Length() < 3) || (!Buffer::HasInstance(args[0]->ToObject())) || 
+NAN_METHOD(Verify) {
+	NanScope();
+	if ((args.Length() < 3) || (!Buffer::HasInstance(args[0]->ToObject())) ||
 		(!Buffer::HasInstance(args[1]->ToObject())) || (!Buffer::HasInstance(args[2]->ToObject()))) {
-		return V8Exception("Verify requires (Buffer, Buffer(64), Buffer(32)");
+		return NanThrowError("Verify requires (Buffer, Buffer(64), Buffer(32)");
 	}
 	Handle<Object> message = args[0]->ToObject();
 	Handle<Object> signature = args[1]->ToObject();
 	Handle<Object> publicKey = args[2]->ToObject();
 	if ((Buffer::Length(signature) != 64) || (Buffer::Length(publicKey) != 32)) {
-		return V8Exception("Verify requires (Buffer, Buffer(64), Buffer(32)");
+		return NanThrowError("Verify requires (Buffer, Buffer(64), Buffer(32)");
 	}
 	unsigned char* messageData = (unsigned char*)Buffer::Data(message);
 	size_t messageLen = Buffer::Length(message);
 	unsigned char* signatureData = (unsigned char*)Buffer::Data(signature);
 	unsigned char* publicKeyData = (unsigned char*)Buffer::Data(publicKey);
-	return scope.Close(Boolean::New(crypto_sign_verify(signatureData, messageData, messageLen, publicKeyData) == 0));
+
+	NanReturnValue(NanNew(crypto_sign_verify(signatureData, messageData, messageLen, publicKeyData) == 0));
 }
 
 
 void InitModule(Handle<Object> exports) {
-	exports->Set(String::NewSymbol("MakeKeypair"), FunctionTemplate::New(MakeKeypair)->GetFunction());
-	exports->Set(String::NewSymbol("Sign"), FunctionTemplate::New(Sign)->GetFunction());
-	exports->Set(String::NewSymbol("Verify"), FunctionTemplate::New(Verify)->GetFunction());
+	exports->Set(NanNew("MakeKeypair"), NanNew<FunctionTemplate>(MakeKeypair)->GetFunction());
+	exports->Set(NanNew("Sign"), NanNew<FunctionTemplate>(Sign)->GetFunction());
+	exports->Set(NanNew("Verify"), NanNew<FunctionTemplate>(Verify)->GetFunction());
 }
 
 NODE_MODULE(native, InitModule)


### PR DESCRIPTION
Ports the native module to nan and new ABI as interfaced by nan.

Every commit is [digitally signed by **ED85FF40**](http://pgp.mit.edu/pks/lookup?op=vindex&search=0x9337CFF2ED85FF40) due to the potentially critical nature of this module.

Cheers.