### PR TITLE
Use Buffer.from throughout

### DIFF
--- a/example.js
+++ b/example.js
@@ -20,16 +20,16 @@ var bobKeypair = ed25519.MakeKeypair(hash);
 	Now some messages
 */
 var message = 'Hi Bob, How are your pet monkeys doing? What were their names again? -Alice';
-var signature = ed25519.Sign(new Buffer(message, 'utf8'), aliceKeypair); //Using Sign(Buffer, Keypair object)
+var signature = ed25519.Sign(Buffer.from(message, 'utf8'), aliceKeypair); //Using Sign(Buffer, Keypair object)
 // or
-var signature2 = ed25519.Sign(new Buffer(message, 'utf8'), aliceKeypair.privateKey); //Using Sign(Buffer, Keypair object)
+var signature2 = ed25519.Sign(Buffer.from(message, 'utf8'), aliceKeypair.privateKey); //Using Sign(Buffer, Keypair object)
 // or
-var signature3 = ed25519.Sign(new Buffer(message, 'utf8'), aliceSeed); //Using Sign(Buffer, Buffer)
+var signature3 = ed25519.Sign(Buffer.from(message, 'utf8'), aliceSeed); //Using Sign(Buffer, Buffer)
 
 // Alice sends her message and signature over to bob.
 
 // Bob being a paranoid fellow and a good friend of alice has her public key and checks the signature.
-if (ed25519.Verify(new Buffer(message, 'utf8'), signature, aliceKeypair.publicKey)) {
+if (ed25519.Verify(Buffer.from(message, 'utf8'), signature, aliceKeypair.publicKey)) {
 	// Bob trusts the message because the Verify function returned true.
 	console.log('Signature valid');
 } else {
@@ -37,12 +37,12 @@ if (ed25519.Verify(new Buffer(message, 'utf8'), signature, aliceKeypair.publicKe
 	console.log('Signature NOT valid');
 }
 // check the other signatures
-if (ed25519.Verify(new Buffer(message, 'utf8'), signature2, aliceKeypair.publicKey)) {
+if (ed25519.Verify(Buffer.from(message, 'utf8'), signature2, aliceKeypair.publicKey)) {
 	console.log('Signature2 valid');
 } else {
 	console.log('Signature2 NOT valid');
 }
-if (ed25519.Verify(new Buffer(message, 'utf8'), signature3, aliceKeypair.publicKey)) {
+if (ed25519.Verify(Buffer.from(message, 'utf8'), signature3, aliceKeypair.publicKey)) {
 	console.log('Signature3 valid');
 } else {
 	console.log('Signature3 NOT valid');

--- a/test/ed25519.js
+++ b/test/ed25519.js
@@ -13,7 +13,7 @@ var data = {
 describe("ed25519", function() {
   describe("#MakeKeypair()", function () {
     it("returns a public and private key", function () {
-      var seed = new Buffer(data.seed, "hex")
+      var seed = Buffer.from(data.seed, "hex")
       var keyPair = ed25519.MakeKeypair(seed);
 
       assert.equal(
@@ -30,17 +30,17 @@ describe("ed25519", function() {
 
   describe("#Sign()", function () {
     it("Generates a valid signature using a seed", function(){
-      var seed = new Buffer(data.seed, "hex")
-      var message = new Buffer(data.message);
+      var seed = Buffer.from(data.seed, "hex")
+      var message = Buffer.from(data.message);
       var signature = ed25519.Sign(message, seed);
 
       assert.equal(signature.toString("hex"), data.signature)
     });
 
     it("Generates a valid signature using a keyPair", function(){
-      var privateKey = new Buffer(data.privateKey, "hex")
-      var publicKey = new Buffer(data.publicKey, "hex")
-      var message = new Buffer(data.message);
+      var privateKey = Buffer.from(data.privateKey, "hex")
+      var publicKey = Buffer.from(data.publicKey, "hex")
+      var message = Buffer.from(data.message);
       var signature = ed25519.Sign(
         message,
         {
@@ -55,17 +55,17 @@ describe("ed25519", function() {
 
   describe("#Verify", function() {
     it("returns true if the signature is valid", function(){
-      var publicKey = new Buffer(data.publicKey, "hex")
-      var signature = new Buffer(data.signature, "hex")
-      var message = new Buffer(data.message);
+      var publicKey = Buffer.from(data.publicKey, "hex")
+      var signature = Buffer.from(data.signature, "hex")
+      var message = Buffer.from(data.message);
 
       assert.ok(ed25519.Verify(message, signature, publicKey));
     });
 
     it("returns false if the signature is not valid", function(){
-      var publicKey = new Buffer(data.publicKey, "hex")
-      var signature = new Buffer(data.invalidSignature, "hex")
-      var message = new Buffer(data.message);
+      var publicKey = Buffer.from(data.publicKey, "hex")
+      var signature = Buffer.from(data.invalidSignature, "hex")
+      var message = Buffer.from(data.message);
 
       assert.ifError(ed25519.Verify(message, signature, publicKey));
     });


### PR DESCRIPTION
This small pull request replaces `new Buffer(string, encoding)` calls with newfangled `Buffer.from (string, encoding)`, in keeping with changes in Node.js.  The best word on those changes I could find is [this Medium post from the bloke who merged the change](https://medium.com/@jasnell/node-js-buffer-api-changes-3c21f1048f97), which in turn links to the PR, in case you want all the nitty-gritty.

On a totally related note: Thanks very much for this binding.  I've found it very useful more than a few times, when all I need is Ed25519, and not, say, all of nacl.