### PR TITLE
Update to support Node 10 and OpenSSL 1.1.1a:

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A native implementation of Ed25519(http://ed25519.cr.yp.to/) for node.js
 ## Installation
 npm install ed25519
 
+### Windows Prerequisites
+1. Install Python version 2.7 from https://www.python.org/ . You can install just for your local user account or for all users. Version 2.7 is required for building the Ed25519 native code package. Set the path to python.exe in the PYTHON environment variable.
+1. Install Visual Studio 2017 Build Tools from https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15 . Select the Visual C++ Build Tools suite from the Workloads tab.
+1. (Windows) Install the latest Win64 version of the full (non-Lite) installer for OpenSSL from https://slproweb.com/products/Win32OpenSSL.html to `c:\OpenSSL-Win64`
+
 ## Usage
 For usage details see the example.js file.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ npm install ed25519
 ### Windows Prerequisites
 1. Install Python version 2.7 from https://www.python.org/ . You can install just for your local user account or for all users. Version 2.7 is required for building the Ed25519 native code package. Set the path to python.exe in the PYTHON environment variable.
 1. Install Visual Studio 2017 Build Tools from https://www.visualstudio.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15 . Select the Visual C++ Build Tools suite from the Workloads tab.
-1. (Windows) Install the latest Win64 version of the full (non-Lite) installer for OpenSSL from https://slproweb.com/products/Win32OpenSSL.html to `c:\OpenSSL-Win64`
+1. (Windows) Install the latest Win64 version of the full (non-Lite) installer for OpenSSL from https://slproweb.com/products/Win32OpenSSL.html to `c:\OpenSSL-Win64` . Version 1.1.1a or higher is required.
 
 ## Usage
 For usage details see the example.js file.

--- a/binding.gyp
+++ b/binding.gyp
@@ -85,7 +85,7 @@
 			}],
 		  ],
 		  'libraries': [ 
-			'-l<(openssl_root)/lib/libeay32.lib',
+  			'-l<(openssl_root)/lib/libcrypto.lib',
 		  ],
 		  'include_dirs': [
 			'<(openssl_root)/include',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "ed25519",
+  "version": "0.0.5",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bindings": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+    },
+    "nan": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "ed25519",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "An Ed25519 implementation for node.js",
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "^2.0.9"
+    "nan": "^2.11.1"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Update to latest nan package that contains a fix for Windows build error: node_modules\nan\nan_maybe_43_inl.h(112): error C2039: 'ForceSet': is not a member of 'v8::Object' (compiling source file ..\src\ed25519.cc) [C:\PassportSqrl\node_modules\ed25519\build\ed25519.vcxproj]
- Fix gyp path to OpenSSL on Windows to handle layout changes in 1.1.0+
 - Add prereq info in README to make it easier to get started
- Add package-lock.json